### PR TITLE
feat: add a description only visible to screen readers

### DIFF
--- a/components/FoldingInstructions/index.tsx
+++ b/components/FoldingInstructions/index.tsx
@@ -36,6 +36,9 @@ const FoldingInstructions = () => {
           height={94}
           alt={t('one.title')}
         />
+        <figcaption id="step-1-caption" className="is-sr-only">
+          {t('one.description')}
+        </figcaption>
       </figure>
       <figure>
         <ImageExplicitWidthAndHeight
@@ -44,7 +47,11 @@ const FoldingInstructions = () => {
           width={156}
           height={94}
           alt={t('two.title')}
+          longdesc="#step-2-caption"
         />
+        <figcaption id="step-2-caption" className="is-sr-only">
+          {t('two.description')}
+        </figcaption>
       </figure>
       <figure>
         <ImageExplicitWidthAndHeight
@@ -53,7 +60,11 @@ const FoldingInstructions = () => {
           width={156}
           height={94}
           alt={t('three.title')}
+          longdesc="#step-3-caption"
         />
+        <figcaption id="step-3-caption" className="is-sr-only">
+          {t('three.description')}
+        </figcaption>
       </figure>
       <figure>
         <ImageExplicitWidthAndHeight
@@ -62,7 +73,11 @@ const FoldingInstructions = () => {
           width={156}
           height={94}
           alt={t('four.title')}
+          longdesc="#step-4-caption"
         />
+        <figcaption id="step-4-caption" className="is-sr-only">
+          {t('four.description')}
+        </figcaption>
       </figure>
       <figure>
         <ImageExplicitWidthAndHeight
@@ -71,7 +86,11 @@ const FoldingInstructions = () => {
           width={156}
           height={94}
           alt={t('five.title')}
+          longdesc="#step-5-caption"
         />
+        <figcaption id="step-5-caption" className="is-sr-only">
+          {t('five.description')}
+        </figcaption>
       </figure>
       <figure>
         <ImageExplicitWidthAndHeight
@@ -80,7 +99,11 @@ const FoldingInstructions = () => {
           width={156}
           height={94}
           alt={t('six.title')}
+          longdesc="#step-6-caption"
         />
+        <figcaption id="step-6-caption" className="is-sr-only">
+          {t('six.description')}
+        </figcaption>
       </figure>
       <figure>
         <ImageExplicitWidthAndHeight
@@ -89,7 +112,11 @@ const FoldingInstructions = () => {
           width={156}
           height={94}
           alt={t('seven.title')}
+          longdesc="#step-7-caption"
         />
+        <figcaption id="step-7-caption" className="is-sr-only">
+          {t('seven.description')}
+        </figcaption>
       </figure>
     </Carousel>
   );

--- a/components/ImageExplicitWidthAndHeight/index.tsx
+++ b/components/ImageExplicitWidthAndHeight/index.tsx
@@ -22,6 +22,9 @@ const ImageExplicitWidthAndHeight = ({
           imgs.forEach((img) => {
             img.setAttribute('width', '' + width);
             img.setAttribute('height', '' + height);
+            // This code is placed here because longdesc attribute is not
+            // recognized by the Image component. Remove this code when
+            // this attribute will be supported by the Image component.
             if (longdesc != undefined) {
               img.setAttribute('longdesc', '' + longdesc);
             }

--- a/components/ImageExplicitWidthAndHeight/index.tsx
+++ b/components/ImageExplicitWidthAndHeight/index.tsx
@@ -1,7 +1,14 @@
 import styles from './ImageExplicitWidthAndHeight.module.scss';
 import Image from 'next/image';
 
-const ImageExplicitWidthAndHeight = ({ id, src, width, height, alt }: any) => {
+const ImageExplicitWidthAndHeight = ({
+  id,
+  src,
+  width,
+  height,
+  alt,
+  longdesc,
+}: any) => {
   return (
     <div id={id} className={styles.imageExplicitWidthAndHeight}>
       <Image
@@ -15,6 +22,9 @@ const ImageExplicitWidthAndHeight = ({ id, src, width, height, alt }: any) => {
           imgs.forEach((img) => {
             img.setAttribute('width', '' + width);
             img.setAttribute('height', '' + height);
+            if (longdesc != undefined) {
+              img.setAttribute('longdesc', '' + longdesc);
+            }
           });
         }}
       />

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -50,31 +50,31 @@
           "steps": {
             "one": {
               "title": "Primer pas",
-              "description": ""
+              "description": "Col·loca el full amb la cara escrita per tu mirant amunt de manera que el teu missatge quedi a la vista. "
             },
             "two": {
               "title": "Segon pas",
-              "description": ""
+              "description": "Fes el primer doblec per la línea puntejada que hi ha al revers del full. Et quedarà a la vista el dibuix del \"missatge en l'ampolla\"."
             },
             "three": {
               "title": "Tercer pas",
-              "description": ""
+              "description": "Doblega ara per l'altra línea puntejada del revers del full."
             },
             "four": {
               "title": "Quart pas",
-              "description": ""
+              "description": "Aquest doblec ocultarà l'anterior."
             },
             "five": {
               "title": "Cinquè pas",
-              "description": ""
+              "description": "Aquest és l'últim doblec. No té línies puntejades. Es tracta d'introduir un extrem del paper doblegat dins de l'altre. El de la dreta fa de sobre i el de l'esquerra és el que s'introdueix dins de l'altre."
             },
             "six": {
               "title": "Sisè pas",
-              "description": ""
+              "description": "S'ha d'introduir fins la línea de punts."
             },
             "seven": {
               "title": "Setè pas",
-              "description": ""
+              "description": "Per rematar el doblec aixafa'l contra una superfície plana. Veuràs que un costat t'ha quedat totalment blanc i l'altre té el logotip d'ANONYMATH."
             }
           }
         },

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -49,25 +49,32 @@
           "description": "Aquestes són les instruccions per tal que puguis plegar el full en el que has escrit el teu missatge de manera que el seu contingut quedi ocult. La plantilla t'ajudarà en el procés.",
           "steps": {
             "one": {
-              "title": "Primer pas"
+              "title": "Primer pas",
+              "description": ""
             },
             "two": {
-              "title": "Segon pas"
+              "title": "Segon pas",
+              "description": ""
             },
             "three": {
-              "title": "Tercer pas"
+              "title": "Tercer pas",
+              "description": ""
             },
             "four": {
-              "title": "Quart pas"
+              "title": "Quart pas",
+              "description": ""
             },
             "five": {
-              "title": "Cinquè pas"
+              "title": "Cinquè pas",
+              "description": ""
             },
             "six": {
-              "title": "Sisè pas"
+              "title": "Sisè pas",
+              "description": ""
             },
             "seven": {
-              "title": "Setè pas"
+              "title": "Setè pas",
+              "description": ""
             }
           }
         },

--- a/messages/en.json
+++ b/messages/en.json
@@ -49,25 +49,32 @@
           "description": "",
           "steps": {
             "one": {
-              "title": ""
+              "title": "",
+              "description": ""
             },
             "two": {
-              "title": ""
+              "title": "",
+              "description": ""
             },
             "three": {
-              "title": ""
+              "title": "",
+              "description": ""
             },
             "four": {
-              "title": ""
+              "title": "",
+              "description": ""
             },
             "five": {
-              "title": ""
+              "title": "",
+              "description": ""
             },
             "six": {
-              "title": ""
+              "title": "",
+              "description": ""
             },
             "seven": {
-              "title": ""
+              "title": "",
+              "description": ""
             }
           }
         },

--- a/messages/es.json
+++ b/messages/es.json
@@ -49,25 +49,32 @@
           "description": "Estas son las instrucciones para que puedas plegar la hoja en la que has escrito tu mensaje de tal forma que su contenido quede oculto. La plantilla te ayudará en el proceso.",
           "steps": {
             "one": {
-              "title": "Primer paso"
+              "title": "Primer paso",
+              "description": "Coloca la hoja con la parte impresa hacia abajo. De esta forma lo que has escrito quedará a la vista."
             },
             "two": {
-              "title": "Segundo paso"
+              "title": "Segundo paso",
+              "description": "Haz el primer pliegue a lo largo de la línea punteada que hay en el dorso. Te quedará a la vista el dibujo del \"mensaje en la botella\"."
             },
             "three": {
-              "title": "Tercer paso"
+              "title": "Tercer paso",
+              "description": "Pliega ahora el otro lado de la hoja, también por la línea punteada."
             },
             "four": {
-              "title": "Cuarto paso"
+              "title": "Cuarto paso",
+              "description": "Este pliego tapará en anterior."
             },
             "five": {
-              "title": "Quinto paso"
+              "title": "Quinto paso",
+              "description": "Este es el último plegado. No tiene líneas punteadas. Se trata de introducir un extremo del papel doblado dentro del otro. El de la derecha hace de sobre y el de la izquierda es el que se introduce dentro del otro."
             },
             "six": {
-              "title": "Sexto paso"
+              "title": "Sexto paso",
+              "description": "Se debe introducir hasta la línea de puntos."
             },
             "seven": {
-              "title": "Séptimo paso"
+              "title": "Séptimo paso",
+              "description": "Aplástalo contra la superficie plana para acabar el plegado. Verás que un lado la superficie es blanca y por el otro se ve el logo de ANONYMATH."
             }
           }
         },

--- a/messages/es.json
+++ b/messages/es.json
@@ -50,7 +50,7 @@
           "steps": {
             "one": {
               "title": "Primer paso",
-              "description": "Coloca la hoja con la parte impresa hacia abajo. De esta forma lo que has escrito quedará a la vista."
+              "description": "Coloca la hoja con la parte escrita por ti hacia arriba de manera que tu mensaje quede a la vista."
             },
             "two": {
               "title": "Segundo paso",
@@ -58,11 +58,11 @@
             },
             "three": {
               "title": "Tercer paso",
-              "description": "Pliega ahora el otro lado de la hoja, también por la línea punteada."
+              "description": "Pliega ahora por la otra línea punteada del dorso."
             },
             "four": {
               "title": "Cuarto paso",
-              "description": "Este pliego tapará en anterior."
+              "description": "Este pliegue tapará el anterior."
             },
             "five": {
               "title": "Quinto paso",
@@ -74,7 +74,7 @@
             },
             "seven": {
               "title": "Séptimo paso",
-              "description": "Aplástalo contra la superficie plana para acabar el plegado. Verás que un lado la superficie es blanca y por el otro se ve el logo de ANONYMATH."
+              "description": "Para acabar el plegado aplástalo contra una superficie plana. Verás que un lado es blanco y el otro tiene el logo de ANONYMATH."
             }
           }
         },


### PR DESCRIPTION
closes #49 

@qbreis ahora los pasos de plegado tienen un texto que explica el paso. Está principalmente pensado para los lectores de pantalla. Verás que el atributo longdesc he tenido que ponerlo de la misma forma que pones el height y width, esto es así porque el Image de Next.js no reconoce ese atributo (que tiene miga la cosa) o no he sabido ver cómo ponerlo de una forma más natural. He usado una clase de Bulma para solo mostrarlo a lectores de pantalla.
En este caso, como en otras ocasiones, creo que no añadiré tests E2E ya que creo que las validaciones de accesibilidad deben ir por otro camino (como las de Lighthouse).